### PR TITLE
Add support for EL 8 appstream install

### DIFF
--- a/README.md
+++ b/README.md
@@ -961,6 +961,11 @@ be installed from the regular repository. Defaults to `true`.
 If the postgresql.org repo is installed, you can install several versions of
 postgres. Defaults to `9.6` in module version 6.0+ and `9.4` in older versions.
 
+#### `manage_dnf_module`
+
+If `true`, enable specified postgresql version appstream for EL 8 systems. Also
+override $server_package_name within postgresql module.  Defaults to false.
+
 Implementation
 ---------------
 

--- a/manifests/database/postgresql.pp
+++ b/manifests/database/postgresql.pp
@@ -8,6 +8,7 @@ class puppetdb::database::postgresql (
   $database_password           = $puppetdb::params::database_password,
   $database_port               = $puppetdb::params::database_port,
   $manage_database             = $puppetdb::params::manage_database,
+  $manage_dnf_module           = $puppetdb::params::manage_dnf_module,
   $manage_server               = $puppetdb::params::manage_dbserver,
   $manage_package_repo         = $puppetdb::params::manage_pg_repo,
   $postgres_version            = $puppetdb::params::postgres_version,
@@ -22,6 +23,7 @@ class puppetdb::database::postgresql (
 
   if $manage_server {
     class { '::postgresql::globals':
+      manage_dnf_module   => $manage_dnf_module,
       manage_package_repo => $manage_package_repo,
       version             => $postgres_version,
     }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -90,6 +90,7 @@ class puppetdb (
   String[1] $cleanup_timer_interval        = $puppetdb::params::cleanup_timer_interval,
   Integer[1] $dlo_max_age                  = $puppetdb::params::dlo_max_age,
   Optional[Stdlib::Absolutepath] $java_bin = $puppetdb::params::java_bin,
+  Boolean  $manage_dnf_module              = $puppetdb::params::manage_dnf_module
 ) inherits puppetdb::params {
 
   class { '::puppetdb::server':
@@ -192,6 +193,7 @@ class puppetdb (
       database_port               => $database_port,
       manage_server               => $manage_dbserver,
       manage_database             => $manage_database,
+      manage_dnf_module           => $manage_dnf_module,
       manage_package_repo         => $manage_package_repo,
       postgres_version            => $postgres_version,
       postgresql_ssl_on           => $postgresql_ssl_on,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -18,6 +18,7 @@ class puppetdb::params inherits puppetdb::globals {
   $database                  = $puppetdb::globals::database
   $manage_dbserver           = true
   $manage_database           = true
+  $manage_dnf_module         = false
 
   if $::osfamily =~ /RedHat|Debian/ {
     $manage_pg_repo            = true


### PR DESCRIPTION
This allows passing `manage_dnf_module` to postgresql::globals module.